### PR TITLE
pkp/pkp-lib#9959 use createTextNode for article title in order to esc…

### DIFF
--- a/filter/PreprintCrossrefXmlFilter.php
+++ b/filter/PreprintCrossrefXmlFilter.php
@@ -159,7 +159,7 @@ class PreprintCrossrefXmlFilter extends \PKP\plugins\importexport\native\filter\
 
         // contributors
         $authors = $publication->getData('authors');
-        if (!empty($authors)) {
+        if ($authors->count() != 0) {
             $contributorsNode = $doc->createElementNS($deployment->getNamespace(), 'contributors');
 
             $isFirst = true;
@@ -221,7 +221,8 @@ class PreprintCrossrefXmlFilter extends \PKP\plugins\importexport\native\filter\
 
         // Titles
         $titlesNode = $doc->createElementNS($deployment->getNamespace(), 'titles');
-        $titlesNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'title', $publication->getLocalizedTitle($submission->getLocale(), 'html')));
+        $titlesNode->appendChild($node = $doc->createElementNS($deployment->getNamespace(), 'title'));
+        $node->appendChild($doc->createTextNode($publication->getLocalizedTitle($submission->getLocale(), 'html')));
         if ($subtitle = $publication->getLocalizedSubTitle($submission->getLocale(), 'html')) {
             $titlesNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'subtitle', $subtitle));
         }
@@ -231,7 +232,7 @@ class PreprintCrossrefXmlFilter extends \PKP\plugins\importexport\native\filter\
         $postedContentNode->appendChild($this->createPostedDateNode($doc, $publication->getData('datePublished')));
 
         // abstract
-        $abstracts = $publication->getData('abstract');
+        $abstracts = $publication->getData('abstract') ?: [];
         foreach($abstracts as $lang => $abstract) {
             $abstractNode = $doc->createElementNS($deployment->getJATSNamespace(), 'jats:abstract');
             $abstractNode->setAttributeNS($deployment->getXMLNamespace(), 'xml:lang', LocaleConversion::getIso1FromLocale($lang));


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/9959

Also another fixes: If there is no authors, !empty($authors) is not working for the LazyCollection. 
Fixes also the warning that null is given as 1. parameter for `foreach(abstracts`.