### PR TITLE
[pkp/pkp-lib#12553] Considers DOI versioning setting in preprint deposit

### DIFF
--- a/filter/PreprintCrossrefXmlFilter.php
+++ b/filter/PreprintCrossrefXmlFilter.php
@@ -17,6 +17,7 @@ namespace APP\plugins\generic\crossref\filter;
 use APP\core\Application;
 use APP\plugins\generic\crossref\CrossrefExportDeployment;
 use APP\publication\Publication;
+use PKP\context\Context;
 use DOMDocument;
 use PKP\i18n\LocaleConversion;
 use PKP\submission\PKPSubmission;
@@ -64,10 +65,16 @@ class PreprintCrossrefXmlFilter extends \PKP\plugins\importexport\native\filter\
         $bodyNode = $doc->createElementNS($deployment->getNamespace(), 'body');
         $rootNode->appendChild($bodyNode);
 
+        $doiVersioning = (bool) ($context->getData(Context::SETTING_DOI_VERSIONING) ?? true);
         foreach ($pubObjects as $pubObject) {
-            $publications = $pubObject->getData('publications')->toArray();
-            // Use array reverse so that the latest version of the submission is first in the xml output and the DOI relations do not cause an error with Crossref
-            $publications = array_reverse($publications, true);
+            if (!$doiVersioning) {
+                $publications = [$pubObject->getCurrentPublication()];
+            } else {
+                $publications = $pubObject->getData('publications')->toArray();
+                // Use array reverse so that the latest version of the submission is first in the xml output and the DOI relations do not cause an error with Crossref
+                $publications = array_reverse($publications, true);
+            }
+
             foreach ($publications as $publication) {
                 if ($publication->getDoi() && $publication->getData('status') === PKPSubmission::STATUS_PUBLISHED) {
                     $postedContentNode = $this->createPostedContentNode($doc, $publication, $pubObject);
@@ -118,7 +125,8 @@ class PreprintCrossrefXmlFilter extends \PKP\plugins\importexport\native\filter\
         $plugin = $deployment->getPlugin();
         $headNode = $doc->createElementNS($deployment->getNamespace(), 'head');
         $headNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'doi_batch_id', htmlspecialchars($context->getData('acronym', $context->getPrimaryLocale()) . '_' . time(), ENT_COMPAT, 'UTF-8')));
-        $headNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'timestamp', date('YmdHisv')));
+        $timestamp = (new \DateTime())->format('YmdHisv');
+        $headNode->appendChild($doc->createElementNS($deployment->getNamespace(), 'timestamp', $timestamp));
         $depositorNode = $doc->createElementNS($deployment->getNamespace(), 'depositor');
         $depositorName = $plugin->getSetting($context->getId(), 'depositorName');
         if (empty($depositorName)) {


### PR DESCRIPTION
Check issue [pkp-lib 12553](https://github.com/pkp/pkp-lib/issues/12553)

This PR also adds a small refactoring in the timestamp, since [date](https://www.php.net/manual/en/function.date.php) doesn't have a microseconds precision (`v` param).